### PR TITLE
Fix for empty string class name

### DIFF
--- a/scalatags/js/src/scalatags/JsDom.scala
+++ b/scalatags/js/src/scalatags/JsDom.scala
@@ -149,7 +149,7 @@ object JsDom
           if (!a.raw) {
             if (a.name == "class") {
               v.toString.split(" ").foreach { cls =>
-                t.classList.add(cls.trim)
+                if (cls.trim.nonEmpty) t.classList.add(cls.trim)
               }
             } else t.setAttribute(a.name, v.toString)
           } else {


### PR DESCRIPTION
classList.add("") throws an exception that is somehow swallowed.